### PR TITLE
Single-quote literals parsed wrong, when contain paired double quotes

### DIFF
--- a/lib/Text/Xslate/Util.pm
+++ b/lib/Text/Xslate/Util.pm
@@ -105,10 +105,10 @@ sub literal_to_value {
     my($value) = @_;
     return $value if not defined $value;
 
-    if($value =~ s/"(.*)"/$1/xms){
+    if($value =~ s/^\s*"(.*)"\s*$/$1/xms){
         $value =~ s/\\(.)/$esc2char{$1} || $1/xmseg;
     }
-    elsif($value =~ s/'(.*)'/$1/xms) {
+    elsif($value =~ s/^\s*'(.*)'\s*$/$1/xms) {
         $value =~ s/\\(['\\])/$1/xmsg; # ' for poor editors
     }
     elsif($value =~ /\A [+-]? $NUMBER \z/xmso) {

--- a/t/020_interface/005_util.t
+++ b/t/020_interface/005_util.t
@@ -50,6 +50,8 @@ my @set = (
     [ q{"-10"},   "-10" ],
     [ q{"-10.0"}, "-10.0" ],
 
+    [q{'test="test"'},q{test="test"}],
+    [q{"test='test'"},q{test='test'}],
 );
 
 foreach my $d(@set) {


### PR DESCRIPTION
'test="test"' became 'test=test' instead of test="test"

I've fixed regexps and add 2 more tests
