### PR TITLE
html_builder escape args

### DIFF
--- a/lib/Text/Xslate/Util.pm
+++ b/lib/Text/Xslate/Util.pm
@@ -59,7 +59,7 @@ sub escaped_string; *escaped_string = \&mark_raw;
 sub html_builder (&){
     my($code_ref) = @_;
     return sub {
-        my $ret = $code_ref->(map { unmark_raw($_) } @_);
+        my $ret = $code_ref->(map { unmark_raw(html_escape($_)) } @_);
         return ref($ret) eq 'CODE'
             ? html_builder(\&{$ret})
             : mark_raw($ret);

--- a/t/020_interface/005_util.t
+++ b/t/020_interface/005_util.t
@@ -112,6 +112,11 @@ $hb = html_builder {
     return sprintf "<%d>", $x + $y;
 };
 is $hb->(1, 2), "<3>";
+$hb = html_builder {
+    my($x, $y) = @_;
+    return sprintf "%s%s", $x, $y;
+};
+is $hb->('<br>', mark_raw('<br>')), "&lt;br&gt;<br>";
 
 # uri_escape
 


### PR DESCRIPTION
# soozyで話していた件ですが

やはり、html_builderはescape済みの引数をcoderefに渡すべきなんじゃないかなと思います。
理由は
1. "html"_builderなので、coderefに入る瞬間にcontextがhtml出力と同等に切り替わると考えるべきだから。これはtype => 'text'であってもhtml_builderな関数を使う場合は一環していると思います。
2. unmark_rawしてcoderefに引数を渡しているので本来もっていた文字列クラス情報が失われておりcoderef側でescapeすべきかどうかが判断できない

あたりです。

この変更を反映するとTT2Likeの直近のコミットのようにhtml_builderの中のcoderefで
html_escapeを直接呼んでいると(unmark_rawしているため)escapeが二重になってしまうので
直接呼ぶべきではないというポリシーにするべきだとは思いますです。

いかがでしょうか。
