### PR TITLE
use catfile for portability (as Xslate does internally)

### DIFF
--- a/t/900_bugs/026_issue61.t
+++ b/t/900_bugs/026_issue61.t
@@ -6,6 +6,7 @@ use warnings;
 use Fatal qw(open close);
 use Test::More;
 use File::Temp qw(tempdir);
+use File::Spec ();
 use Text::Xslate;
 
 # problems on depend cache
@@ -53,7 +54,8 @@ T
     is $tx->render("main.tx"), $content_base;
     is $tx->render("main.tx"), $content_base;
 
-    is $tx->{_load_source_count}{"$service/main.tx"} => 1;
+    my $path = File::Spec->catfile($service, "main.tx");
+    is $tx->{_load_source_count}{$path} => 1;
 
 }
 


### PR DESCRIPTION
This test is failing on Windows because of the different file path separator.
