### PR TITLE
bugfix. conbined utf8 string and bytes.

### DIFF
--- a/lib/Text/Xslate.pm
+++ b/lib/Text/Xslate.pm
@@ -524,7 +524,7 @@ sub _load_compiled {
         }
         elsif($c->[0] eq 'literal') {
             # force upgrade to avoid UTF-8 key issues
-            utf8::upgrade($c->[1]);
+            utf8::upgrade($c->[1]) if($is_utf8);
         }
         push @asm, $c;
     }

--- a/t/900_bugs/038_conbine_flaged_utf8_and_other.t
+++ b/t/900_bugs/038_conbine_flaged_utf8_and_other.t
@@ -1,0 +1,50 @@
+#!perl
+
+use strict;
+use warnings;
+
+BEGIN{
+#    $ENV{XSLATE} = ' dump=ast '; # @@@ @@@
+}
+use Text::Xslate;
+
+use Test::More;
+use File::Temp qw(tempdir);
+
+my %vpath = (
+    ascii => "あ<: foo('i') :>う",
+    utf   => "あ<: foo('い') :>う",
+);
+
+my $tmpdir = tempdir(DIR => ".", CLEANUP => 1);
+
+my %opts = (
+    path      => \%vpath,
+    cache     => 1,
+    cache_dir => $tmpdir,
+    type => 'html', # enable auto escape
+    input_layer => ':bytes',
+    function => {
+        foo => sub {
+            my $s = shift;
+#            warn "[$s][", (utf8::is_utf8($s) ? 'utf' : 'binary'), "]\n";
+            Text::Xslate::mark_raw($s);
+        },
+    },
+);
+
+my $tx = Text::Xslate->new(\%opts);
+
+foreach my $type ('original', 'cached'){
+    my $tx = Text::Xslate->new(%opts);
+
+    foreach my $try (1, 2){
+        is($tx->render('ascii'), q{あiう},  "$type $try ascii");
+        is($tx->render('utf'),   q{あいう},  "$type $try utf");
+    }
+}
+
+$tmpdir = tempdir(DIR => ".", CLEANUP => 1);
+
+done_testing;
+


### PR DESCRIPTION
literal from cache is force upgrade to utf8 string.
if template file is not utf8 string, it cause moji-bake.

I'm not sure this patch is corrent.
because I dont know what is "UTF-8 key issues'.

anyway all tests are passed.
