### PR TITLE
Escape braces by default.

### DIFF
--- a/lib/Text/Xslate/PP.pm
+++ b/lib/Text/Xslate/PP.pm
@@ -64,6 +64,8 @@ our %html_escape = (
     '>' => '&gt;',
     '"' => '&quot;',
     "'" => '&#39;', # IE8 doesn't support &apos; in title
+    "{" => '&#123;',
+    "}" => '&#125;',
 );
 our $html_metachars = sprintf '[%s]', join '', map { quotemeta } keys %html_escape;
 

--- a/src/Text-Xslate.xs
+++ b/src/Text-Xslate.xs
@@ -593,6 +593,12 @@ tx_sv_cat_with_html_escape_force(pTHX_ SV* const dest, SV* const src) {
             // CopyToken("&apos;", d);
             CopyToken("&#39;", d);
         }
+        else if(c == '{') {
+            CopyToken("&#123;", d);
+        }
+        else if(c == '}') {
+            CopyToken("&#125;", d);
+        }
         else {
             *(d++) = c;
         }

--- a/t/010_internals/017_render.t
+++ b/t/010_internals/017_render.t
@@ -28,7 +28,7 @@ $tx = Text::Xslate->new(
 );
 
 is $tx->render('func.tx', { lang => 'Xslate' }),
-    "Hello, {Xslate} world!\n";
+    "Hello, &#123;Xslate&#125; world!\n";
 
 for(1 .. 2) {
     my $tx = Text::Xslate->new({ cache => 0, path => [path] });

--- a/t/020_interface/005_util.t
+++ b/t/020_interface/005_util.t
@@ -109,6 +109,7 @@ is     unmark_raw('&lt;Xslate&gt;'),       '&lt;Xslate&gt;';
 cmp_ok unmark_raw('&lt;Xslate&gt;'), 'eq', '&lt;Xslate&gt;';
 
 is html_escape(q{ & ' " < > }),  qq{ &amp; &#39; &quot; &lt; &gt; }, 'html_escape()'; # '
+is html_escape(q! { } !),  qq{ &#123; &#125; }, 'html_escape()'; # '
 is html_escape('<Xslate>'), '&lt;Xslate&gt;', 'html_escape()';
 is html_escape(html_escape('<Xslate>')), '&lt;Xslate&gt;', 'duplicated html_escape()';
 


### PR DESCRIPTION
Xslate doesn't escape braces by current implementation.
AngularJS thinks braces are special chars.
In edge case, Xslate+AngularJS makes XSS.

This patch makes xslate, escape braces by default.

https://github.com/angular/angular.js/issues/5601
