### PR TITLE
added test for empty result bug

### DIFF
--- a/t/900_bugs/044_empty_result.t
+++ b/t/900_bugs/044_empty_result.t
@@ -1,0 +1,12 @@
+#!perl -w
+use strict;
+use Test::More;
+use Text::Xslate;
+
+my $tx = Text::Xslate->new();
+
+is($tx->render_string('1'), '1');
+is($tx->render_string('0'), '0');
+
+done_testing;
+


### PR DESCRIPTION
https://github.com/xslate/p5-Text-Xslate/issues/111

```
$ prove -lvr  t/900_bugs/044_empty_result.t
[14:15:46] t/900_bugs/044_empty_result.t .. 
ok 1
not ok 2

#   Failed test at t/900_bugs/044_empty_result.t line 9.
#          got: ''
#     expected: '0'
1..2
# Looks like you failed 1 test of 2.
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/2 subtests 
[14:15:46]

Test Summary Report
-------------------
t/900_bugs/044_empty_result.t (Wstat: 256 Tests: 2 Failed: 1)
  Failed test:  2
  Non-zero exit status: 1
Files=1, Tests=2,  0 wallclock secs ( 0.02 usr  0.00 sys +  0.07 cusr  0.00 csys =  0.09 CPU)
Result: FAIL
```
