### PR TITLE
Fix case that input is '0'

### DIFF
--- a/lib/Text/Xslate/Parser.pm
+++ b/lib/Text/Xslate/Parser.pm
@@ -311,7 +311,7 @@ sub split :method {
 
     my $in_tag = 0;
 
-    while($_) {
+    while($_ ne '') {
         if($in_tag) {
             my $start = 0;
             my $pos;


### PR DESCRIPTION
If input is only string '0', then loop condition is false and
loop body is not evaluated. This loop should test whether `$_`
is empty string, not `$_` is false.

Output of #111  is 

```
% perl -MText::Xslate -E '$t=Text::Xslate->new; $t->render_string("1") eq "1" ? say "OK" : say "ERR"'
OK
% perl -MText::Xslate -E '$t=Text::Xslate->new; $t->render_string("0") eq "0" ? say "OK" : say "ERR"'
OK
```

This fix is related to #111, #112.

Please see this patch.
