### PR TITLE
Update author requirements

### DIFF
--- a/author/requires.cpanm
+++ b/author/requires.cpanm
@@ -2,7 +2,7 @@
 Module::Install
 Module::Install::XSUtil
 Module::Install::AuthorTests
-Module::Install::ExtendsMakeTest
+Module::Install::TestTarget
 Module::Install::Repository
 
 # for testing


### PR DESCRIPTION
Module::Install::ExtendsMakeTest is no longer used and
its installation causes travis-ci failure.
