### PR TITLE
We allow test failure with Perl 5.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ perl:
   - "5.8"
   - "5.10"
   - "5.18"
+matrix:
+  allow_failures:
+    - perl: "5.8"


### PR DESCRIPTION
Because with perl 5.8, some dependencies of author tests(Mojolicious, Test::Vars etc)
cannot be installed.
