### PR TITLE
Skip test on Windows system(#120)

### DIFF
--- a/t/900_bugs/041_cachedir_other_process.t
+++ b/t/900_bugs/041_cachedir_other_process.t
@@ -8,6 +8,8 @@ use File::Spec;
 use Time::HiRes qw(sleep);
 use Text::Xslate;
 
+plan skip_all => 'fork emulation does not work' if $^O eq 'MSWin32';
+
 rmtree(cache_dir);
 
 my $tx = Text::Xslate->new(


### PR DESCRIPTION
Because all tests are passed but Perl is crashed after tests finished.
Fork emulation may not work in this case.

Cc: @zdm
