### PR TITLE
Fix issue130

### DIFF
--- a/src/Text-Xslate.xs
+++ b/src/Text-Xslate.xs
@@ -1077,7 +1077,7 @@ tx_invoke_load_file(pTHX_ SV* const self, SV* const name, SV* const mtime, bool 
     PUSHs(boolSV(from_include));
     PUTBACK;
 
-    call_method("load_file", G_EVAL | G_VOID);
+    call_method("load_file", G_EVAL | G_VOID | G_DISCARD);
     if(TX_CATCH_ERROR()){
         dMY_CXT;
         SV* const msg = PL_diehook == MY_CXT.die_handler

--- a/t/900_bugs/045_issue130.t
+++ b/t/900_bugs/045_issue130.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Test::More;
+use Text::Xslate;
+
+my $tx = Text::Xslate->new(
+    path => {
+        'body.tx' => ': block body | reverse -> { include text }',
+        'text.tx' => 'Text::Xslate',
+    },
+    function => {
+        reverse => sub { scalar reverse $_[0]; },
+    },
+);
+
+{
+    my $warnings = '';
+    is($tx->render('body.tx'), 'etalsX::txeT');
+    is($warnings, '');
+}
+
+done_testing;


### PR DESCRIPTION
Text::Xslate::load_file returns value and it is pushed on stack. But tx_invoke_load_file function does not pop stack(and never use it), then stack pointer is incorrect after calling tx_invoke_load_file.
    
This patch sets G_DISCARD flag to call_method(Text::Xslate::load_file) for getting rid of return value from stack automatically.

I confirmed [test1](https://github.com/xslate/p5-Text-Xslate/issues/130#issue-42141613), [test2](https://github.com/xslate/p5-Text-Xslate/issues/130#issuecomment-113747980) are passed with this change.

Please review this patch. This is related to #130.