### PR TITLE
Remove 5.8 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ before_install:
   - perlbrew install-cpanm -f
   - cpanm --notest < author/requires.cpanm
 perl:
-  - "5.8"
   - "5.10"
   - "5.18"
   - "5.20"
-matrix:
-  allow_failures:
-    - perl: "5.8"


### PR DESCRIPTION
Because dependency module 'Test::Vars' requires Perl 5.10 or higher.

See
- https://travis-ci.org/xslate/p5-Text-Xslate/jobs/76598190