### PR TITLE
Fix test for DragonflyBSD

### DIFF
--- a/t/900_bugs/023_deploy_problem.t
+++ b/t/900_bugs/023_deploy_problem.t
@@ -50,6 +50,8 @@ sub write_file {
 
     open my($fh), ">", $file;
     print $fh $content;
+    $fh->flush;
+    $fh->sync;
     close $fh;
     return;
 }


### PR DESCRIPTION
mtime of file is not updated after closing file on DragonflyBSD file
system, such as UFS. This causes test failure. It seems mtime is update
after fflush and fsync.

Test are failed on many Dragonfly BSD environment.
- http://matrix.cpantesters.org/?dist=Text-Xslate%203.3.7;os=dragonfly;reports=1