### PR TITLE
Fix issue 156 segmentation fault issue

### DIFF
--- a/src/Text-Xslate.xs
+++ b/src/Text-Xslate.xs
@@ -874,9 +874,13 @@ tx_macro_enter(pTHX_ tx_state_t* const txst, AV* const macro, tx_pc_t const reta
         for(NOOP; i < outer; i++) {
             IV const real_ix = i + TXframe_START_LVAR;
             /* XXX: macros can refer to unallocated lvars */
-            SV* const sv = AvFILLp(oframe) >= real_ix
-                ? sv_mortalcopy(AvARRAY(oframe)[real_ix])
-                : &PL_sv_undef;
+            SV* sv;
+            SV* v = AvARRAY(oframe)[real_ix];
+            if (v != NULL && AvFILLp(oframe) >= real_ix) {
+                 sv = sv_mortalcopy(v);
+            } else {
+                 sv = &PL_sv_undef;
+            }
             av_store(cframe, real_ix , sv);
             SvREFCNT_inc_simple_void_NN(sv);
         }

--- a/t/900_bugs/046_issue156.t
+++ b/t/900_bugs/046_issue156.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use Test::More;
+use Text::Xslate;
+
+my $base = <<'EOF';
+: if 0 {
+   : my $var = [ ];
+: }
+: for ['default'] -> $t {
+: }
+: block content -> { }
+Good
+EOF
+
+my $xslate1 = Text::Xslate->new(
+    path => {
+       'base.tx' => $base,
+       'page.tx' => q{: cascade "base.tx"},
+    },
+    warn_handler => sub { die @_ },
+);
+my $res1 = $xslate1->render('page.tx', { });
+is $res1, "Good\n";
+
+done_testing;


### PR DESCRIPTION
Check array element is not NULL. Because AvARRAY element is NULL instead of &PL_sv_undef since Perl 5.19.3.

See also
- https://github.com/Perl/perl5/commit/ce0d59fdd1c7d145efdf6bf8da56a259fed483e4

This is related to #156, #157.
CC: @xinminglai Could you check this patch ?