### PR TITLE
Dynamic function examples

### DIFF
--- a/example/dynamic_functions.pl
+++ b/example/dynamic_functions.pl
@@ -1,0 +1,47 @@
+#!perl -w
+use strict;
+use Text::Xslate;
+use FindBin qw($Bin);
+ 
+{
+    package MyBridge;
+ 
+    use parent qw(Text::Xslate::Bridge);
+ 
+    __PACKAGE__->bridge(
+        function => {my_func => \&_my_func},
+        scalar   => {my_func => \&_scalar},
+        hash     => {my_func => \&_hash},
+        array    => {my_func => \&_array},
+    );
+
+    sub _scalar {
+        my $obj = shift;
+        _my_func(@_)->($obj);
+    };
+
+    sub _hash {
+        my $obj = shift;
+        _my_func(@_)->(map {$_, $obj->{$_}} keys %$obj);
+    };
+
+    sub _array {
+        my $obj = shift;
+        _my_func(@_)->(@$obj);
+    };
+
+    sub _my_func {
+        my @outer_args = @_;
+        sub {
+            my (@inner_args) = @_;
+            join(', ', @outer_args, @inner_args) . "\n";
+        }
+    }
+}
+
+my $tx = Text::Xslate->new(
+    module => [qw(MyBridge)],
+    path   => $Bin,
+);
+
+print $tx->render('dynamic_functions.tx');

--- a/example/dynamic_functions.tx
+++ b/example/dynamic_functions.tx
@@ -1,0 +1,17 @@
+Block syntax:
+: block my_block | my_func(foo => 'bar') -> {'baz, qux'}
+
+Subroutine syntax:
+: my_func(foo => 'bar')('baz, qux');
+
+Filter syntax:
+: 'baz, qux' | my_func(foo => 'bar')
+
+Scalar object syntax:
+: 'baz, qux'.my_func(foo => 'bar')
+
+Hash object syntax:
+: {baz => 'qux'}.my_func(foo => 'bar')
+
+Array object syntax:
+: ['baz', 'qux'].my_func(foo => 'bar')

--- a/lib/Text/Xslate/Syntax/Kolon.pm
+++ b/lib/Text/Xslate/Syntax/Kolon.pm
@@ -314,6 +314,10 @@ Functions are just Perl's subroutines, so you can define dynamic functions
     : $value | indent("> ") # Template-Toolkit like
     : indent("> ")($value)  # This is also valid
 
+C<example/dynamic_functions.tx> has examples of dynamic functions being used
+with block, function and filter syntax, and with scalar, hash and array
+objects.
+
 There are several builtin functions, which you cannot redefine:
 
     : $var | mark_raw   # marks it as a raw string


### PR DESCRIPTION
Text::Xslate::Syntax::Kolon briefly discusses dynamic functions.  This
revision adds examples of how they can be used with block, function and
filter syntax, and with scalar, hash and array objects.