### PR TITLE
fix concat operator with undef variables

### DIFF
--- a/lib/Text/Xslate/PP.pm
+++ b/lib/Text/Xslate/PP.pm
@@ -443,6 +443,11 @@ sub tx_match { # simple smart matching
 
 sub tx_concat {
     my($lhs, $rhs) = @_;
+    if (!defined $lhs){
+        return $rhs;
+    }elsif(!defined $rhs){
+        return $lhs;
+    }
     if(ref($lhs) eq TXt_RAW) {
         if(ref($rhs) eq TXt_RAW) {
             return Text::Xslate::Util::mark_raw(${ $lhs } . ${ $rhs });

--- a/src/xslate_opcode.inc
+++ b/src/xslate_opcode.inc
@@ -317,6 +317,17 @@ TXC_w_sv(concat) {
     SvGETMAGIC(lhs);
     SvGETMAGIC(rhs);
 
+    if(!SvOK(lhs)){
+        sv_setsv_nomg(sv, rhs);
+        TX_st_sa = sv;
+        TX_RETURN_NEXT();
+    }
+    if(!SvOK(rhs)){
+        sv_setsv_nomg(sv, lhs);
+        TX_st_sa = sv;
+        TX_RETURN_NEXT();
+    }
+
     if(tx_str_is_raw(aTHX_ aMY_CXT_ lhs)) {
         sv_setsv_nomg(sv, TX_UNMARK_RAW(lhs));
 

--- a/t/900_bugs/047_undef_concat.t
+++ b/t/900_bugs/047_undef_concat.t
@@ -1,0 +1,44 @@
+#!perl
+# https://github.com/xslate/p5-Text-Xslate/issues/xx
+use strict;
+use warnings;
+use Test::More;
+
+use utf8;
+use Text::Xslate 'mark_raw';
+my $xslate = Text::Xslate->new();
+
+# without the fix, these fail with 
+# "Use of uninitialized value in subroutine entry"
+
+
+my $t = sub {
+    is $xslate->render_string('<: $s1 ~ $s2 :>', shift), shift;
+};
+
+$t->( {s1 => 'A',   s2 => 'B'   } => 'AB');
+$t->( {s1 => 'A',   s2 => undef } => 'A');
+$t->( {s1 => undef, s2 => 'B'   } => 'B');
+
+$t->( {s1 => mark_raw('A'),   s2 => undef           } => 'A');
+$t->( {s1 => undef,           s2 => mark_raw('B')   } => 'B');
+
+
+# the automatic html-escaping that xslate does
+$t->({s1 => 'A',             s2 => '<B>'           } => 'A&lt;B&gt;');
+$t->({s1 => 'A',             s2 => mark_raw('<B>') } => 'A<B>'      );
+
+$t->({s1 => '<A>',           s2 => 'B'             } => '&lt;A&gt;B');
+$t->({s1 => mark_raw('<A>'), s2 => 'B'             } => '<A>B'      );
+
+# those two again with undefs
+$t->({s1 => '<A>',           s2 => undef           } => '&lt;A&gt;');
+$t->({s1 => mark_raw('<A>'), s2 => undef           } => '<A>');
+
+$t->({s1 => undef,           s2 => '<B>'           } => '&lt;B&gt;');
+$t->({s1 => undef,           s2 => mark_raw('<B>') } => '<B>');
+
+# undef on both sides
+$t->({s1 => undef,           s2 => undef           } => '');
+
+done_testing();


### PR DESCRIPTION
Generally xslate handles undefined `$variables` silently. But in the case of
concatenation with the ~ operator, it dies with the message

    Use of uninitialized value in subroutine entry

This change to the concat operator handling makes `$A ~ $B` not fail if either
is undef, which is consistent with the rest of xslate's behavior.