### PR TITLE
Unexpected HTML escaping in macro concatenation

### DIFF
--- a/t/900_bugs/049_issue173.t
+++ b/t/900_bugs/049_issue173.t
@@ -1,0 +1,36 @@
+#!perl -w
+use strict;
+use Test::More;
+
+use Text::Xslate;
+
+my $tx = Text::Xslate->new(syntax => 'Kolon');
+
+my $tmpl;
+
+$tmpl = <<'TX';
+: macro br  { raw('<br>') }
+: macro div { raw('<div>' ~ br()  ~ '</div>') }
+: div()
+TX
+
+is $tx->render_string($tmpl), '<div><br></div>', 'macro concat';
+
+$tmpl = <<'TX';
+: macro br  { raw('<br>') }
+: macro div { raw(['<div>', br(), '</div>'].join('')) }
+: div()
+TX
+
+is $tx->render_string($tmpl), '<div><br></div>', 'macro join';
+
+$tmpl = <<'TX';
+: macro br        { raw('<br>') }
+: macro div_open  { raw('<div>') }
+: macro div_close { raw('</div>') }
+: div_open() ~ br() ~ div_close()
+TX
+
+is $tx->render_string($tmpl), '<div><br></div>', 'template concat';
+
+done_testing;


### PR DESCRIPTION
When macro A concatenates strings with the output of macro B, and both
macros mark their output as raw, the strings from macro A are
unexpectedly HTML escaped.  This only happens with the concatenation
operator when used inside a macro.  HTML escaping is not applied if the
join method is used instead of the concatenation operator, or if the
concatenation operator is used outside of a macro.