### PR TITLE
fix regression from commit 6c653f35abd894014a957b0fea048f35fe5e1d53

### DIFF
--- a/lib/Text/Xslate/PP.pm
+++ b/lib/Text/Xslate/PP.pm
@@ -443,10 +443,11 @@ sub tx_match { # simple smart matching
 
 sub tx_concat {
     my($lhs, $rhs) = @_;
-    if (!defined $lhs){
-        return $rhs;
-    }elsif(!defined $rhs){
-        return $lhs;
+    if (!defined $lhs) {
+        $lhs = "";
+    }
+    if (!defined $rhs) {
+        $rhs = "";
     }
     if(ref($lhs) eq TXt_RAW) {
         if(ref($rhs) eq TXt_RAW) {

--- a/src/xslate_opcode.inc
+++ b/src/xslate_opcode.inc
@@ -329,14 +329,10 @@ TXC_w_sv(concat) {
     SvGETMAGIC(rhs);
 
     if(!SvOK(lhs)){
-        sv_setsv_nomg(sv, rhs);
-        TX_st_sa = sv;
-        TX_RETURN_NEXT();
+        sv_setpvs(TX_st_sb, "");
     }
     if(!SvOK(rhs)){
-        sv_setsv_nomg(sv, lhs);
-        TX_st_sa = sv;
-        TX_RETURN_NEXT();
+        sv_setpvs(TX_st_sa, "");
     }
 
     if(tx_str_is_raw(aTHX_ aMY_CXT_ lhs)) {

--- a/t/900_bugs/047_undef_concat.t
+++ b/t/900_bugs/047_undef_concat.t
@@ -41,4 +41,19 @@ $t->({s1 => undef,           s2 => mark_raw('<B>') } => '<B>');
 # undef on both sides
 $t->({s1 => undef,           s2 => undef           } => '');
 
+my $t_ref = sub {
+    is $xslate->render_string('<: $s1 :>', shift), shift;
+};
+
+package TestOverload {
+    use overload fallback => 1, '""' => sub { ${$_[0]} };
+};
+
+my $blessed = do {
+    my $str = "<A>";
+    bless(\$str, 'TestOverload');
+};
+$t_ref->({ s1 => $blessed } => '&lt;A&gt;');
+
 done_testing();
+


### PR DESCRIPTION
By default, xslate will try to coerce the returned scalar to string if
it's reference. We shouldn't return early in this case, the returned
blessed reference makes xslate fail.