### PR TITLE
Fixed typo in documentation

### DIFF
--- a/lib/Text/Xslate.pm
+++ b/lib/Text/Xslate.pm
@@ -963,7 +963,7 @@ in order to pre-process template.
 
 For example:
 
-    # Remove withespace from templates
+    # Remove whitespace from templates
     my $tx = Text::Xslate->new(
         pre_process_handler => sub {
             my $text = shift;


### PR DESCRIPTION
"withespace" -> "whitespace"