### PR TITLE
improves perl 5.8 support

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -6,6 +6,7 @@ requires 'Scalar::Util', '1.14';
 
 on configure => sub {
     requires 'Module::Build::XSUtil';
+    requires 'version', '0.9913';
 };
 
 on test => sub {

--- a/lib/Text/Xslate.pm
+++ b/lib/Text/Xslate.pm
@@ -4,7 +4,7 @@ use 5.008_001;
 use strict;
 use warnings;
 
-our $VERSION = '3.4.0';
+use version; our $VERSION = version->declare('v3.4.0');
 
 use Carp              ();
 use File::Spec        ();

--- a/lib/Text/Xslate/PP.pm
+++ b/lib/Text/Xslate/PP.pm
@@ -3,7 +3,7 @@ package Text::Xslate::PP;
 use 5.008_001;
 use strict;
 
-our $VERSION = '3.4.0';
+use version; our $VERSION = version->declare('v3.4.0');
 
 BEGIN{
     $ENV{XSLATE} = ($ENV{XSLATE} || '') . '[pp]';

--- a/lib/Text/Xslate/PP/Opcode.pm
+++ b/lib/Text/Xslate/PP/Opcode.pm
@@ -2,7 +2,7 @@ package Text::Xslate::PP::Opcode;
 use Mouse;
 extends qw(Text::Xslate::PP::State);
 
-our $VERSION = '3.4.0';
+use version; our $VERSION = version->declare('v3.4.0');
 
 use Carp ();
 use Scalar::Util ();

--- a/src/xslate.h
+++ b/src/xslate.h
@@ -1,4 +1,5 @@
 /* xslate.h */
+#define NEED_gv_fetchpvn_flags
 #include "xshelper.h"
 
 #if defined(__GNUC__) && !defined(TX_NO_DTC)


### PR DESCRIPTION
This PR improves perl 5.8 support.

### (A) 34d26b1

Currently Xslate cannot be built on perl 5.8 with Devel::PPPort 3.33+.
This commit will fix this.
See also https://github.com/mhx/Devel-PPPort/issues/42

### (B) f9258de

Currently [t/900_bugs/030_issue71.t](https://github.com/xslate/p5-Text-Xslate/blob/master/t/900_bugs/030_issue71.t) fails on perl 5.8.

In recent perl, SvUPGRADE(av, SVt_PVAV) makes the av AvREAL_only,
so that av_fill() frees deleted elements.
https://github.com/Perl/perl5/blob/v5.26.1/sv.c#L1357
https://github.com/Perl/perl5/blob/v5.26.1/av.c#L860-L865

On the other hand, in perl 5.8, SvUPGRADE(av, SVt_PVAV) does **NOT** make the av AvREAL_only,
so that av_fill() does **NOT** free deleted elements, and it implies memory leaks.
https://github.com/Perl/perl5/blob/perl-5.8.5/sv.c#L1462-L1476
https://github.com/Perl/perl5/blob/perl-5.8.5/av.c#L767-L772

The commit f9258de makes `newframe` AvREAL_only (= AvREIFY_off + AvREAL_on) explicitly.

### (C) 2e5392a

Use version->declare syntax; otherwise we'll get:
```
❯ XSLATE=xs perl -Mblib -MText::Xslate -e1
Text::Xslate object version v3.4.0 does not match bootstrap parameter 3.4.0 at /Users/skaji/env/plenv/versions/5.8.5/lib/perl5/5.8.5/darwin-2level/DynaLoader.pm line 253.
```