### PR TITLE
xt/200_depended.t: installdeps with --notest

### DIFF
--- a/xt/200_depended.t
+++ b/xt/200_depended.t
@@ -8,10 +8,6 @@ use constant LDIR => '.test_deps';
 BEGIN{ rmtree(LDIR) }
 END  { rmtree(LDIR) }
 
-my @opts = qw(-q --reinstall);
-if(!scalar grep { $_ eq '--install' } @ARGV) {
-    push @opts, '-l', LDIR;
-}
 my $cpanm = which('cpanm') or plan skip_all => 'no cpanm';
 
 my @modules = qw(
@@ -21,7 +17,8 @@ my @modules = qw(
 
 foreach my $mod(@modules) {
     note $mod;
-    is system($^X, $cpanm, @opts, $mod), 0, $mod;
+    is system($^X, $cpanm, -l => LDIR, qw(-nq --installdeps), $mod), 0, $mod;
+    is system($^X, $cpanm, -l => LDIR, qw(-q --test-only), $mod), 0, $mod;
 }
 
 done_testing;


### PR DESCRIPTION
In xt/200_depended.t, we run tests for not only Text::Xslate::Bridge::TT2Like and Catalyst::View::Xslate, but also their dependencies.

I don't think this is necessary, so skip running tests for the dependencies;
this makes travis-ci much faster. 