### PR TITLE
fix test for windows

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -15,7 +15,7 @@ on configure => sub {
 };
 
 on test => sub {
-    requires 'Test::More', '0.88';
+    requires 'Test::More', '0.98';
     requires 'Test::Requires';
     requires 'File::Copy::Recursive';
     requires 'File::Path', '2.07';

--- a/t/010_internals/008_files.t
+++ b/t/010_internals/008_files.t
@@ -3,106 +3,93 @@ use strict;
 use Test::More;
 
 use Text::Xslate;
-use FindBin qw($Bin);
 use lib "t/lib";
 use Util;
 use File::Copy qw(copy move);
-use File::Path qw(rmtree);
+use File::Spec;
 
 use Fatal qw(utime);
 
-my @files  = (path."/hello.tx",  path."/for.tx");
-my @caches;
+subtest normal => sub {
+    Util::reinit();
 
-rmtree cache_dir;
-my $x = path."/hello.tx";
-END{
-    move "$x.save" => $x if $x && -f "$x.save";
-    rmtree cache_dir;
-}
-
-{
     my $tx = Text::Xslate->new(
         path      => [path],
         cache_dir => cache_dir,
     );
 
-    push @caches, $tx->find_file($_)->{cachepath}
-        for qw(hello.tx for.tx);
-}
+    my @files = map { File::Spec->catfile(path, $_) } qw(hello.tx for.tx);
+    my @caches = map { $tx->find_file($_)->{cachepath} } qw(hello.tx for.tx);
 
-for(1 .. 10) {
-    my $tx = Text::Xslate->new(
-        path      => [path],
-        cache_dir => cache_dir,
-    );
+    for(1 .. 10) {
+        my $tx = Text::Xslate->new(
+            path      => [path],
+            cache_dir => cache_dir,
+        );
 
-    is $tx->render('hello.tx', { lang => 'Xslate' }),
-        "Hello, Xslate world!\n", "file (preload $_)";
+        is $tx->render('hello.tx', { lang => 'Xslate' }),
+            "Hello, Xslate world!\n", "file (preload $_)";
 
-    is $tx->render('for.tx', { books => [ { title => "Foo" }, { title => "Bar" } ]}),
-        "[Foo]\n[Bar]\n", "file (preload $_)";
+        is $tx->render('for.tx', { books => [ { title => "Foo" }, { title => "Bar" } ]}),
+            "[Foo]\n[Bar]\n", "file (preload $_)";
 
-    ok -e $_, "$_ exists" for @caches;
+        ok -e $_, "$_ exists" for @caches;
 
-    if(($_ % 3) == 0) {
-        my $t = time + $_;
-        utime $t, $t, @caches;
+        if(($_ % 3) == 0) {
+            my $t = time + $_;
+            utime $t, $t, @caches;
+        }
     }
-}
 
-for(1 .. 10) {
+    for(1 .. 10) {
+        my $tx = Text::Xslate->new(path => [path], cache_dir => cache_dir);
+
+        is $tx->render('hello.tx', { lang => 'Xslate' }),
+            "Hello, Xslate world!\n", "file (on demand $_)";
+
+        is $tx->render('for.tx', { books => [ { title => "Foo" }, { title => "Bar" } ]}),
+            "[Foo]\n[Bar]\n", "file (on demand $_)";
+
+        if(($_ % 3) == 0) {
+            my $t = time() + $_*10;
+            utime $t, $t, @files;
+        }
+    }
+};
+
+subtest 'cache => 1 (default mode)' => sub {
+    Util::reinit();
+
+    my $x = File::Spec->catfile(path, "hello.tx");
     my $tx = Text::Xslate->new(path => [path], cache_dir => cache_dir);
 
+    is $tx->render('hello.tx', { lang => 'Xslate' }), "Hello, Xslate world!\n", "file";
+
+    # change the content
+    copy "$x.mod", $x;
+
+    utime $^T+10, $^T+10, $x;
+
+    is $tx->render('hello.tx', { lang => 'Perl' }),
+        "Hi, Perl.\n", "auto reload $_" for 1 .. 2;
+};
+
+subtest 'cache => 2 (release mode)' => sub {
+    Util::reinit();
+
+    my $x = File::Spec->catfile(path, "hello.tx");
+    my $tx = Text::Xslate->new(cache => 2, path => [path], cache_dir => cache_dir);
+
     is $tx->render('hello.tx', { lang => 'Xslate' }),
-        "Hello, Xslate world!\n", "file (on demand $_)";
+        "Hello, Xslate world!\n", "first" for 1 .. 2;
 
-    is $tx->render('for.tx', { books => [ { title => "Foo" }, { title => "Bar" } ]}),
-        "[Foo]\n[Bar]\n", "file (on demand $_)";
+    # change the content
+    copy "$x.mod", $x;
 
-    if(($_ % 3) == 0) {
-        my $t = time() + $_*10;
-        utime $t, $t, @files;
-    }
-}
+    utime $^T+10, $^T+10, $x;
 
-unlink @caches;
-
-my $tx = Text::Xslate->new(path => [path], cache_dir => cache_dir);
-
-is $tx->render('hello.tx', { lang => 'Xslate' }), "Hello, Xslate world!\n", "file";
-
-# change the content
-move  $x      => "$x.save";
-copy "$x.mod" =>  $x;
-
-utime $^T+10, $^T+10, $x;
-
-is $tx->render('hello.tx', { lang => 'Perl' }),
-    "Hi, Perl.\n", "auto reload $_" for 1 .. 2;
-
-move "$x.save" => $x or diag "cannot move $x.save to $x: $!";
-
-unlink @caches;
-
-note 'cache => 2 (release mode)';
-
-$tx = Text::Xslate->new(cache => 2, path => [path], cache_dir => cache_dir);
-
-utime $^T, $^T, $x;
-
-is $tx->render('hello.tx', { lang => 'Xslate' }),
-    "Hello, Xslate world!\n", "first" for 1 .. 2;
-
-# change the content
-move  $x      => "$x.save";
-copy "$x.mod" =>  $x;
-
-utime $^T+10, $^T+10, $x;
-
-is $tx->render('hello.tx', { lang => 'Xslate' }),
-    "Hello, Xslate world!\n", "second (modified, but not reloaded)" for 1 .. 2;
-
-
+    is $tx->render('hello.tx', { lang => 'Xslate' }),
+        "Hello, Xslate world!\n", "second (modified, but not reloaded)" for 1 .. 2;
+};
 
 done_testing;

--- a/t/lib/Util.pm
+++ b/t/lib/Util.pm
@@ -19,7 +19,12 @@ sub reinit {
     if ($^O eq 'MSWin32') {
         # On windows, File::Copy::copy equals Win32::CopyFile, which preserves mtime.
         # In our case, we need to ensure that mtime of copied files are now
-        find({wanted => sub { utime $^T, $^T, $_ if -f }, no_chdir => 1}, $path);
+        my $wanted = sub {
+            return unless -f;
+            $_ = $1 if /(.+)/; # untaint
+            utime $^T, $^T, $_;
+        };
+        find({wanted => $wanted, no_chdir => 1}, $path);
     }
     $cache_dir = tempdir CLEANUP => 1;
 }


### PR DESCRIPTION
On windows, t\010_internals\007_compile_errs.t sometimes fails.
See https://ci.appveyor.com/project/gfx/p5-text-xslate/build/1.0.4

t\010_internals\007_compile_errs.t assumes that the mtime of template files for it are now.
On windows, File::Copy::copy equals Win32::CopyFile, which preserves the original mtime.
So the mtime of template files for test may not be now.

This PR sets mtime now manually on windows.