### PR TITLE
Guarantee that test cleans up after itself.

### DIFF
--- a/t/900_bugs/040_issue95.t
+++ b/t/900_bugs/040_issue95.t
@@ -8,6 +8,8 @@ use Test::More;
 
 use Text::Xslate;
 
+use File::Temp qw(tempdir);
+
 # here's some test template files
 my $base_a = <<'EOF';
 here is base A
@@ -41,6 +43,7 @@ my $tx = Text::Xslate->new(
     path => ['path_b', 'path_a'],
 
     cache => 1,
+    cache_dir => tempdir(CLEANUP => 1),
 );
 
 my $out = $tx->render('sub.tx');
@@ -62,6 +65,7 @@ $tx = Text::Xslate->new(
     path => ['path_b', 'path_a'],
 
     cache => 1,
+    cache_dir => tempdir(CLEANUP => 1),
 );
 
 note 'after re-creating an Xslate instance';


### PR DESCRIPTION
The constructors in 040_issue95.t were not specifying a value for 'cache_dir'.
As a consequence, directories and files created during testing were being
placed underneath user's home directory and not being removed automatically.

Have those directories and files be created in temporary directories with
automatic cleanup.