### PR TITLE
Ensure that test cleans up after itself.

### DIFF
--- a/t/020_interface/017_validate.t
+++ b/t/020_interface/017_validate.t
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 use Test::More;
+use File::Temp ( qw| tempdir | );
 
 use Text::Xslate;
 
@@ -23,7 +24,10 @@ Hello, <: $xslate ??? :> world!
 T
 );
 
-my $tx = Text::Xslate->new(path => [\%vpath]);
+my $tx = Text::Xslate->new(
+    path => [\%vpath],
+    cache_dir => tempdir(CLEANUP => 1),
+);
 
 foreach my $name (qw(ok0 ok1)) {
     eval { $tx->validate($name) };

--- a/t/040_tterse/008_methods.t
+++ b/t/040_tterse/008_methods.t
@@ -4,7 +4,10 @@ use Test::More;
 
 use Text::Xslate;
 
-my $tx = Text::Xslate->new(syntax => 'TTerse');
+my $tx = Text::Xslate->new(
+    syntax => 'TTerse',
+    cache => 0,
+);
 
 {
     package Obj;

--- a/t/040_tterse/018_process.t
+++ b/t/040_tterse/018_process.t
@@ -121,6 +121,7 @@ my %vpath = (
 my $tx = Text::Xslate->new(
     syntax => 'TTerse',
     path   => \%vpath,
+    cache  => 0,
     header => ['wrap_begin'],
     footer => ['wrap_end'],
 );

--- a/t/900_bugs/019_nested_mm.t
+++ b/t/900_bugs/019_nested_mm.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use utf8;
 use Test::More;
+use File::Temp ( qw| tempdir | );
 
 use Text::Xslate;
 
@@ -29,7 +30,8 @@ T
 );
 
 my $xslate = Text::Xslate->new(
-    path => [\%vpath]
+    path => [\%vpath],
+    cache_dir => tempdir(CLEANUP => 1),
 );
 is eval { $xslate->render('Z') }, "This is Z.\n";
 is $@, '';

--- a/t/900_bugs/033_ex_safe_render.t
+++ b/t/900_bugs/033_ex_safe_render.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
+use File::Temp ( qw| tempdir | );
 
 {
     package MyCounter;
@@ -26,6 +27,7 @@ my $tx = Text::Xslate->new(
             [%- mymacro() -%]
         },
     },
+    cache_dir => tempdir(CLEANUP => 1),
 );
 
 ok $tx->render('recurse.tt', { recurse_count => MyCounter->new(count => 101) });

--- a/t/900_bugs/045_issue130.t
+++ b/t/900_bugs/045_issue130.t
@@ -11,6 +11,7 @@ my $tx = Text::Xslate->new(
     function => {
         reverse => sub { scalar reverse $_[0]; },
     },
+    cache => 0,
 );
 
 {

--- a/t/900_bugs/046_issue156.t
+++ b/t/900_bugs/046_issue156.t
@@ -19,6 +19,7 @@ my $xslate1 = Text::Xslate->new(
        'page.tx' => q{: cascade "base.tx"},
     },
     warn_handler => sub { die @_ },
+    cache => 0,
 );
 my $res1 = $xslate1->render('page.tx', { });
 is $res1, "Good\n";


### PR DESCRIPTION
Test was leaving data in ~/.xslate_cache.  Tests should use tempdirs rather
than leaving data under tester's home directory.

Follow-up to last comment in https://github.com/xslate/p5-Text-Xslate/pull/189