### PR TITLE
define XS_VERSION

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ lib/Text/Xslate/PP/Const.pm
 /Build
 /_build
 /lib/Text/Xslate.xs
+/src/xs_version.h

--- a/builder/MyBuilder.pm
+++ b/builder/MyBuilder.pm
@@ -23,6 +23,14 @@ sub new {
     $self;
 }
 
+sub _write_xs_version {
+    my ($self, $file) = @_;
+    open my $fh, ">", $file or die "$file: $!";
+    print  {$fh} "#ifndef XS_VERSION\n";
+    printf {$fh} "#  define XS_VERSION \"%s\"\n", $self->dist_version;
+    print  {$fh} "#endif\n";
+}
+
 sub _derive_opcode {
     my ($self, $script, $source, $derived) = @_;
     my @cmd = ($self->{properties}{perl}, $script, $source);
@@ -33,6 +41,10 @@ sub _derive_opcode {
 
 sub ACTION_code {
     my ($self, @args) = @_;
+
+    if (!$self->pureperl_only) {
+        $self->_write_xs_version("src/xs_version.h");
+    }
 
     my @derive = (
         {

--- a/src/xslate_methods.xs
+++ b/src/xslate_methods.xs
@@ -1,3 +1,4 @@
+#include "xs_version.h"
 #include "xslate.h"
 
 #define TXBM_DECL(name) void name \


### PR DESCRIPTION
Fix #192 

In old perls such as 5.8.8, it seems that we should set XS_VERSION to build src/xslate_methods.c:
```
[root@419bfe767e97 p5-Text-Xslate]# gcc -Isrc -I/usr/lib64/perl5/5.8.8/x86_64-linux-thread-multi/CORE -fPIC -Wall -Wextra -Wdeclaration-after-statement -c -D_REENTRANT -D_GNU_SOURCE -fno-strict-aliasing -pipe -Wdeclaration-after-statement -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -I/usr/include/gdbm -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic -E src/xslate_methods.c | grep Text::Xslate::Methods::_guts
    SV *my_cxt_sv = *Perl_hv_fetch(my_perl, (*Perl_Imodglobal_ptr(my_perl)),"Text::Xslate::Methods::_guts" XS_VERSION,sizeof("Text::Xslate::Methods::_guts" XS_VERSION)-1,(1)); my_cxt_t *my_cxtp = (my_cxt_t*)((((my_cxt_sv)->sv_flags & 0x00010000) ? ((XPVUV*) (my_cxt_sv)->sv_any)->xuv_uv : Perl_sv_2uv_flags(my_perl, my_cxt_sv,2)));
        SV *my_cxt_sv = *Perl_hv_fetch(my_perl, (*Perl_Imodglobal_ptr(my_perl)),"Text::Xslate::Methods::_guts" XS_VERSION,sizeof("Text::Xslate::Methods::_guts" XS_VERSION)-1,(1)); my_cxt_t *my_cxtp = (my_cxt_t*)((((my_cxt_sv)->sv_flags & 0x00010000) ? ((XPVUV*) (my_cxt_sv)->sv_any)->xuv_uv : Perl_sv_2uv_flags(my_perl, my_cxt_sv,2)));
    SV *my_cxt_sv = *Perl_hv_fetch(my_perl, (*Perl_Imodglobal_ptr(my_perl)),"Text::Xslate::Methods::_guts" XS_VERSION,sizeof("Text::Xslate::Methods::_guts" XS_VERSION)-1,(1)); my_cxt_t *my_cxtp = (my_cxt_t*)((((my_cxt_sv)->sv_flags & 0x00010000) ? ((XPVUV*) (my_cxt_sv)->sv_any)->xuv_uv : Perl_sv_2uv_flags(my_perl, my_cxt_sv,2)));
    SV *my_cxt_sv = *Perl_hv_fetch(my_perl, (*Perl_Imodglobal_ptr(my_perl)),"Text::Xslate::Methods::_guts" XS_VERSION,sizeof("Text::Xslate::Methods::_guts" XS_VERSION)-1,(1)); my_cxt_t *my_cxtp = (my_cxt_t*)((XPV*) (Perl_newSV(my_perl, sizeof(my_cxt_t)-1))->sv_any)->xpv_pv; ((void)(sizeof(my_cxt_t) > 1 && (1) > ((size_t)~0)/sizeof(my_cxt_t) && (Perl_croak_nocontext(PL_memory_wrap),0)), (void)((__builtin_object_size ((char*)(my_cxtp), 0) != (size_t) -1) ? __builtin___memcpy_chk ((char*)(my_cxtp), (const char*)((my_cxt_t*)((((my_cxt_sv)->sv_flags & 0x00010000) ? ((XPVUV*) (my_cxt_sv)->sv_any)->xuv_uv : Perl_sv_2uv_flags(my_perl, my_cxt_sv,2)))), (1) * sizeof(my_cxt_t), __builtin_object_size ((char*)(my_cxtp), 0)) : __memcpy_ichk ((char*)(my_cxtp), (const char*)((my_cxt_t*)((((my_cxt_sv)->sv_flags & 0x00010000) ? ((XPVUV*) (my_cxt_sv)->sv_any)->xuv_uv : Perl_sv_2uv_flags(my_perl, my_cxt_sv,2)))), (1) * sizeof(my_cxt_t)))); Perl_sv_setuv(my_perl, my_cxt_sv,(UV)(my_cxtp));
    SV *my_cxt_sv = *Perl_hv_fetch(my_perl, (*Perl_Imodglobal_ptr(my_perl)),"Text::Xslate::Methods::_guts" XS_VERSION,sizeof("Text::Xslate::Methods::_guts" XS_VERSION)-1,(1)); my_cxt_t *my_cxtp = (my_cxt_t*)((XPV*) (Perl_newSV(my_perl, sizeof(my_cxt_t)-1))->sv_any)->xpv_pv; ((void)(sizeof(my_cxt_t) > 1 && (1) > ((size_t)~0)/sizeof(my_cxt_t) && (Perl_croak_nocontext(PL_memory_wrap),0)), (void)(__builtin_constant_p ((1) * sizeof(my_cxt_t)) && ((1) * sizeof(my_cxt_t)) == 0 ? (__warn_memset_zero_len (), (void) (0), (void) ((1) * sizeof(my_cxt_t)), (void *) ((char*)(my_cxtp))) : ((__builtin_object_size ((char*)(my_cxtp), 0) != (size_t) -1) ? __builtin___memset_chk ((char*)(my_cxtp), 0, (1) * sizeof(my_cxt_t), __builtin_object_size ((char*)(my_cxtp), 0)) : __memset_ichk ((char*)(my_cxtp), 0, (1) * sizeof(my_cxt_t))))); Perl_sv_setuv(my_perl, my_cxt_sv,(UV)(my_cxtp));
```
This PR will fix it.
  