### PR TITLE
BUG FIX: Arguments list too long

### DIFF
--- a/t/900_bugs/032_issue79.t
+++ b/t/900_bugs/032_issue79.t
@@ -15,11 +15,12 @@ my $dir = "$Bin/issue79";
 
 rmtree "$dir/cache";
 
-my %std_inc = map { $_ => 1 } (".", @Config::Config{qw(
-    sitelibexp sitearchexp
-    privlibexp archlibexp
-)});
-my $libs = join " ", map { qq{"-I$_" } } grep { !$std_inc{$_} } @INC;
+my @include_dirs = (
+  '../../blib/lib',
+  '../blib/lib',
+  './blib/lib'
+);
+my $libs = join " ", map { qq{ "-I$_" } } @include_dirs;
 
 my $run_cmd = qq{$^X $libs "$dir/xslate.pl"};
 note $run_cmd;


### PR DESCRIPTION
This PR addresses Issue #202 by using the blib/lib directory instead
of inheriting the lengthy @INC that can be found on a machine that has
numerous module build directories in it's CPAN build cache.

Closes #202

Signed-off-by: Gary Greene <greeneg@tolharadys.net>