### PR TITLE
do not set INC manually

### DIFF
--- a/t/900_bugs/032_issue79.t
+++ b/t/900_bugs/032_issue79.t
@@ -15,13 +15,7 @@ my $dir = "$Bin/issue79";
 
 rmtree "$dir/cache";
 
-my %std_inc = map { $_ => 1 } (".", @Config::Config{qw(
-    sitelibexp sitearchexp
-    privlibexp archlibexp
-)});
-my $libs = join " ", map { qq{"-I$_" } } grep { !$std_inc{$_} } @INC;
-
-my $run_cmd = qq{$^X $libs "$dir/xslate.pl"};
+my $run_cmd = qq{$^X "$dir/xslate.pl"};
 note $run_cmd;
 
 my @tmpls = qw/ contentA.tt contentB.tt /;


### PR DESCRIPTION
Module::Build or "prove" pass INC via PERL5LIB environment variable,
so we do not need to set INC by ourselves.

This will fix #202 