### PR TITLE
fix t/010_internals/008_files.t

### DIFF
--- a/t/010_internals/008_files.t
+++ b/t/010_internals/008_files.t
@@ -68,7 +68,8 @@ subtest 'cache => 1 (default mode)' => sub {
     # change the content
     copy "$x.mod", $x;
 
-    utime $^T+10, $^T+10, $x;
+    my $t = time + 10;
+    utime $t, $t, $x;
 
     is $tx->render('hello.tx', { lang => 'Perl' }),
         "Hi, Perl.\n", "auto reload $_" for 1 .. 2;
@@ -86,7 +87,8 @@ subtest 'cache => 2 (release mode)' => sub {
     # change the content
     copy "$x.mod", $x;
 
-    utime $^T+10, $^T+10, $x;
+    my $t = time + 10;
+    utime $t, $t, $x;
 
     is $tx->render('hello.tx', { lang => 'Xslate' }),
         "Hello, Xslate world!\n", "second (modified, but not reloaded)" for 1 .. 2;


### PR DESCRIPTION
https://www.cpantesters.org/cpan/report/694c1696-3809-11ec-8d11-e947f7ad8bd4
```
    #   Failed test 'auto reload 1'
    #   at t/010_internals/008_files.t line 74.
    #          got: 'Hello, Perl world!
    # '
    #     expected: 'Hi, Perl.
    # '

    #   Failed test 'auto reload 2'
    #   at t/010_internals/008_files.t line 74.
    #          got: 'Hello, Perl world!
    # '
    #     expected: 'Hi, Perl.
    # '
    # Looks like you failed 2 tests of 3.

#   Failed test 'cache => 1 (default mode)'
#   at t/010_internals/008_files.t line 75.
# Looks like you failed 1 test of 3.
t/010_internals/008_files.t ..................... 
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/3 subtests 
```

Currently we use `$^T + 10` to update file modification time,
but if the test take a lot of time for some reasons, then `$^T + 10` may not update file modification time.

Use `time + 10` to make sure we update file modification time.